### PR TITLE
ci_scripts + metadata-only Fastlane + metadata CI + CLAUDE.md

### DIFF
--- a/.github/workflows/deploy-metadata.yml
+++ b/.github/workflows/deploy-metadata.yml
@@ -1,0 +1,43 @@
+name: Deploy App Store Metadata
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - 'fastlane/metadata/**'
+      - 'fastlane/Deliverfile'
+
+  # Allow manual trigger for initial setup or retries
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install Fastlane
+        run: gem install fastlane
+
+      - name: Deploy metadata to App Store Connect
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.ASC_API_KEY }}
+        run: fastlane deploy_metadata
+
+      - name: Post result
+        if: always()
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "### ✅ Metadata deployed to App Store Connect" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Metadata deployment failed" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/validate-metadata.yml
+++ b/.github/workflows/validate-metadata.yml
@@ -1,0 +1,113 @@
+name: Validate App Store Metadata
+
+on:
+  pull_request:
+    paths:
+      - 'fastlane/metadata/**'
+      - 'fastlane/Deliverfile'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate metadata constraints
+        run: |
+          set -e
+          ERRORS=0
+
+          check_length() {
+            local file="$1" max="$2" label="$3"
+            if [ -f "$file" ]; then
+              len=$(wc -m < "$file" | tr -d ' ')
+              if [ "$len" -gt "$max" ]; then
+                echo "❌ $label: $len chars (max $max)"
+                ERRORS=$((ERRORS + 1))
+              else
+                echo "✅ $label: $len/$max chars"
+              fi
+            else
+              echo "⚠️  $label: file missing"
+            fi
+          }
+
+          check_not_empty() {
+            local file="$1" label="$2"
+            if [ -f "$file" ]; then
+              if [ ! -s "$file" ]; then
+                echo "❌ $label: file is empty"
+                ERRORS=$((ERRORS + 1))
+              fi
+            fi
+          }
+
+          check_no_placeholder() {
+            local file="$1" label="$2"
+            if [ -f "$file" ]; then
+              if grep -qiE '\[TODO\]|\[PLACEHOLDER\]|\[CHANGE ME\]|TBD' "$file"; then
+                echo "❌ $label: contains placeholder text"
+                ERRORS=$((ERRORS + 1))
+              fi
+            fi
+          }
+
+          LOCALE_DIR="fastlane/metadata/en-AU"
+
+          echo "=== Character Limit Checks ==="
+          check_length "$LOCALE_DIR/name.txt" 30 "App Name"
+          check_length "$LOCALE_DIR/subtitle.txt" 30 "Subtitle"
+          check_length "$LOCALE_DIR/description.txt" 4000 "Description"
+          check_length "$LOCALE_DIR/keywords.txt" 100 "Keywords"
+          check_length "$LOCALE_DIR/release_notes.txt" 4000 "Release Notes"
+          check_length "$LOCALE_DIR/promotional_text.txt" 170 "Promotional Text"
+
+          echo ""
+          echo "=== Empty File Checks ==="
+          check_not_empty "$LOCALE_DIR/name.txt" "App Name"
+          check_not_empty "$LOCALE_DIR/description.txt" "Description"
+          check_not_empty "$LOCALE_DIR/keywords.txt" "Keywords"
+
+          echo ""
+          echo "=== Placeholder Checks ==="
+          for f in "$LOCALE_DIR"/*.txt; do
+            check_no_placeholder "$f" "$(basename "$f")"
+          done
+
+          echo ""
+          echo "=== Keyword Checks ==="
+          if [ -f "$LOCALE_DIR/keywords.txt" ]; then
+            # Check for spaces after commas (wastes characters)
+            if grep -q ', ' "$LOCALE_DIR/keywords.txt"; then
+              echo "⚠️  Keywords: remove spaces after commas to save characters"
+            fi
+            # Check for duplicate keywords
+            dupes=$(tr ',' '\n' < "$LOCALE_DIR/keywords.txt" | sed 's/^ *//;s/ *$//' | sort | uniq -d)
+            if [ -n "$dupes" ]; then
+              echo "❌ Keywords: duplicates found: $dupes"
+              ERRORS=$((ERRORS + 1))
+            fi
+            # Check for app name in keywords (Apple ignores it, wastes space)
+            if [ -f "$LOCALE_DIR/name.txt" ]; then
+              app_name=$(cat "$LOCALE_DIR/name.txt" | tr '[:upper:]' '[:lower:]')
+              if grep -qi "$app_name" "$LOCALE_DIR/keywords.txt"; then
+                echo "⚠️  Keywords: contains app name (Apple already indexes it — wasted space)"
+              fi
+            fi
+          fi
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo ""
+            echo "❌ $ERRORS error(s) found. Fix before merging."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All metadata checks passed."
+
+      - name: Diff summary
+        if: always()
+        run: |
+          echo "### Metadata Changes in This PR" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          git diff origin/main -- fastlane/metadata/ | head -100 >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ PricingStructure
 *.pages
 AppStoreMedia
 GoogleService-Info.plist
+# --- fastlane / App Store Connect secrets ---
+fastlane/api_key.json
+fastlane/api_key_.json
+*.p8
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci_scripts"]
+	path = ci_scripts
+	url = git@github.com:markhmwong/ci_scripts.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — Shortlist
+
+Task / list app with an Apple Watch companion. SwiftUI + Combine, Coordinator navigation,
+Core Data persistence, RevenueCat for Pro. Shares `WhizUtilKit`.
+
+## Project layout
+
+```
+Shortlist/
+  Application Delegate/   # App/Scene delegates
+  Coordinator/           # Navigation (Coordinator.swift)
+  TaskList/, Task/, TaskDetails/, TaskList…   # Core task features
+  Calendar/, Views/, BaseClasses/, Extensions/
+  Model/                 # Core Data models
+  ProFeatureManager/     # RevenueCat Pro gating
+  SettingsManager/, Settings/, Settings List/
+Shortlist WatchKit App/  # watchOS companion
+ShortlistTests/, ShortlistUITests/
+ScreenshotTester/        # Fastlane snapshot host
+fastlane/                # Metadata-only (legacy match/snapshot files retained but unused)
+ci_scripts/              # Shared submodule (added)
+*.xcworkspace / *.xcodeproj
+```
+
+`WhizUtilKit` is a shared dependency (sibling repo `WhizUtil`).
+
+## Build & run
+
+Open the **workspace** `Shortlist.xcworkspace`. Scheme `Shortlist` (also `ShortlistWatchKitApp`,
+`ScreenshotScheme`). Bundle ID `com.whizbang.shortlist`, team `GEKZN86RYS`.
+
+```bash
+xcodebuild -workspace Shortlist.xcworkspace -scheme Shortlist \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -configuration Debug build
+```
+
+## Architecture
+
+- **SwiftUI + Combine**, **Coordinator** navigation, **Core Data** persistence.
+- **RevenueCat** via `ProFeatureManager` gates Pro features.
+- WatchKit app mirrors core list functionality.
+
+## Release (Xcode Cloud + Fastlane, metadata-only)
+
+Builds, tests, TestFlight run on **Xcode Cloud**. **Fastlane is metadata-only** — the old
+`beta`/build lanes were removed; fastlane never builds the binary. (Legacy `Matchfile`,
+`gymfile`, `Snapfile` remain but are unused by the metadata lanes.) App Store text under
+`fastlane/metadata/en-AU/`. Lanes: `download_meta`, `validate`, `deploy_metadata`,
+`submit_for_review`. GitHub Actions validate metadata on PRs / deploy on push to `release`.
+`ci_scripts` submodule posts Discord build notifications. See the `ios-release` skill.
+`fastlane/api_key.json` (gitignored) → `~/Development/keys/AuthKey_89962V788Y.p8`.

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -1,0 +1,3 @@
+price_tier(0)
+primary_category("Productivity")
+# secondary_category("Utilities")  # Optional

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,99 +1,73 @@
-# This file contains the fastlane.tools configuration
-# You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
-
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
+# fastlane/Fastfile
+# NOTE: Builds and TestFlight are handled by Xcode Cloud.
+# This Fastfile is metadata-only.
 
 default_platform(:ios)
 
 platform :ios do
-  desc "Push a new beta build to TestFlight"
-  lane :beta do
-    enable_automatic_code_signing
-    increment_build_number
-    build_app(
-      workspace: "Shortlist.xcworkspace",
-      scheme: "Shortlist",
-      include_bitcode: true,
-      export_xcargs: "-allowProvisioningUpdates",
-    )
-    upload_to_testflight
+
+  before_all do
+    api_key_path = File.expand_path("../fastlane/api_key.json", __dir__)
+    if File.exist?(api_key_path)
+      config = JSON.parse(File.read(api_key_path))
+      app_store_connect_api_key(
+        key_id: config["key_id"],
+        issuer_id: config["issuer_id"],
+        key_filepath: config["key_filepath"]
+      )
+    elsif ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]
+      app_store_connect_api_key(
+        key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+        issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+        key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+        is_key_content_base64: true
+      )
+    else
+      UI.user_error!("No App Store Connect API key found. Provide fastlane/api_key.json or set APP_STORE_CONNECT_API_KEY_* env vars.")
+    end
   end
 
-  # desc "Code Signing"
-  # lane :codeSign do
-  #   cert(
-  #       username: "markhmwong@gmail.com"
-  #       )
-  #   sigh(
-  #       force: true, username: "markhmwong@gmail.com"
-  #       )
-  # end
-
-  lane :certs do
-    update_project_team(
-      path: "Shortlist.xcodeproj",
-      teamid: "GEKZN86RYS"
-    )
-    match(type: "appstore", app_identifier: ["com.whizbang.shortlist", "com.whizbang.shortlist.watchkitapp", "com.whizbang.shortlist.watchkitapp.watchkitextension"])
-    match(type: "development", app_identifier: ["com.whizbang.shortlist", "com.whizbang.shortlist.watchkitapp", "com.whizbang.shortlist.watchkitapp.watchkitextension"])
-    match(type: "adhoc", app_identifier: ["com.whizbang.shortlist", "com.whizbang.shortlist.watchkitapp", "com.whizbang.shortlist.watchkitapp.watchkitextension"])
+  desc "Download current metadata from App Store Connect"
+  lane :download_meta do
+    deliver(download_metadata: true)
   end
 
-
-  desc "App Store Release"
-  lane :release do
-    # enable_automatic_code_signing
-    get_provisioning_profile(app_identifier: "com.whizbang.shortlist")
-    get_provisioning_profile(app_identifier: "com.whizbang.shortlist.watchkitapp")
-    get_provisioning_profile(app_identifier: "com.whizbang.shortlist.watchkitapp.watchkitextension")
-
-    increment_build_number
-    increment_version_number(
-      # bump_type: "patch"
-      version_number: "1.2.7" # update this each release
+  desc "Validate metadata locally (dry run — no upload)"
+  lane :validate do
+    deliver(
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      force: true,
+      precheck_include_in_app_purchases: false,
+      run_precheck_before_submit: true,
+      submit_for_review: false
     )
-
-    build_app(
-      workspace: "Shortlist.xcworkspace",
-      scheme: "Shortlist",
-      output_directory: "./fastlane/builds",
-      include_bitcode: true,
-      export_xcargs: "-allowProvisioningUpdates",
-    )
-    # upload
-    upload_to_app_store
   end
 
+  desc "Push metadata to App Store Connect (no binary, no submit)"
+  lane :deploy_metadata do
+    deliver(
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      force: true,
+      precheck_include_in_app_purchases: false,
+      submit_for_review: false
+    )
+  end
 
-	desc "Build App"
-	lane :build do
-    ensure_git_status_clean
-		increment_build_number
-		increment_version_number(
-			#bump_type: "patch"
-			version_number: "1.2.7"
-		)
-		gym
-	end
-
-  #Uses the gymfile with the "build" command
-	desc "App Store Release Update 11/06/2020"
-	lane :ReleaseTheKraken do
-    ensure_git_status_clean
-		get_certificates
-		get_provisioning_profile
-		build
-		upload_to_app_store
-	end
+  desc "Push metadata and submit the latest build for review"
+  lane :submit_for_review do
+    deliver(
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      force: true,
+      precheck_include_in_app_purchases: false,
+      submit_for_review: true,
+      automatic_release: false,
+      submission_information: {
+        add_id_info_uses_idfa: false  # set true if the app uses AdMob/IDFA
+      }
+    )
+  end
 
 end


### PR DESCRIPTION
Brings Shortlist onto the portfolio-standard release pipeline.

- **ci_scripts submodule** — Xcode Cloud post-clone + Discord build notifications.
- **Fastfile replaced** with metadata-only lanes (`download_meta`, `validate`, `deploy_metadata`, `submit_for_review`). The legacy `beta`/build lane is removed — **Xcode Cloud owns builds/TestFlight**. Legacy `Matchfile`/`gymfile`/`Snapfile` left in place but unused by the metadata lanes.
- **Deliverfile** added (Productivity, tier 0).
- **GitHub Actions** metadata validate/deploy. **CLAUDE.md** added.

⚠️ Changes how Shortlist releases (no more local `fastlane beta`). Confirm Deliverfile category. Add GitHub secrets `ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_API_KEY`; `DISCORD_WEBHOOK_URL` in Xcode Cloud; create a `release` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)